### PR TITLE
Update links and add GNU Bash as a hard dependency

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -31,7 +31,7 @@
 <li><a href="ranger.1.html">ranger(1) manpage</a></li>
 <li><a href="pydoc/">Source code documentation</a> generated with pydoc</li>
 <li><a href="https://github.com/ranger/ranger/blob/master/README.md">README</a>, <a href="https://github.com/ranger/ranger/blob/master/HACKING.md">HACKING</a>, <a href="https://github.com/ranger/ranger/tree/master/doc">doc/*</a></li>
-<li><a href="http://wiki.archlinux.org/index.php/Ranger">Arch Linux Wiki</a></li>
+<li><a href="https://wiki.archlinux.org/index.php/Ranger">Arch Linux Wiki</a></li>
 <li>Running "<b>make options</b>" will inform you about how to generate documentation yourself</li>
 </ul>
 
@@ -49,7 +49,7 @@ The cheat sheet for version 1.7.0: (<a href="cheatsheet.png">png</a>, <a href="c
     <li>Multi-column display</li>
     <li>Preview of the selected file/directory</li>
     <li>Common file operations (create/chmod/copy/delete/...)</li>
-    <li>VIM-like console and hotkeys</li>
+    <li>VI-like console and hotkeys</li>
     <li>Renaming multiple files at once</li>
     <li>Automatically determine file types and run them with correct programs</li>
     <li>Change the directory of your shell after exiting ranger</li>
@@ -60,8 +60,9 @@ The cheat sheet for version 1.7.0: (<a href="cheatsheet.png">png</a>, <a href="c
 
 <h2>Dependencies</h2>
 <ul>
-    <li><a href="http://python.org">Python</a> (tested with version 2.7, 3.1, 3.2, 3.3, 3.4) with support for ncurses and (optionally) wide-unicode.</li>
-    <li>A pager (<a href="http://www.gnu.org/software/less/">less</a> by default)</li>
+    <li><a href="https://www.python.org/">Python</a> (tested with version 2.7, 3.1, 3.2, 3.3, 3.4) with support for ncurses and (optionally) wide-unicode.</li>
+    <li><a href="https://www.gnu.org/software/bash/">GNU Bash</a></li>
+    <li>A pager (<a href="http://www.greenwoodsoftware.com/less/">less</a> by default)</li>
 </ul>
 
 <p>
@@ -79,12 +80,12 @@ The cheat sheet for version 1.7.0: (<a href="cheatsheet.png">png</a>, <a href="c
 </p>
 <ul>
     <li>img2txt (from <a href="http://caca.zoy.org/wiki/libcaca">caca-utils</a>) for previewing images in <a href="screenshots/ranger-screenshot_large-image-preview.png">ASCII-art</a></li>
-    <li><a href="http://www.andre-simon.de/doku/highlight/en/highlight.html">highlight</a> for syntax highlighting of code</li>
+    <li><a href="http://www.andre-simon.de/doku/highlight/en/highlight.php">highlight</a> for syntax highlighting of code</li>
     <li><a href="http://www.nongnu.org/atool/">atool</a> for previews of archives</li>
-    <li><a href="http://lynx.browser.org">lynx</a>, <a href="http://w3m.sourceforge.net/">w3m</a> or <a href="http://elinks.or.cz/">elinks</a> for previews of html pages</li>
+    <li><a href="http://lynx.invisible-island.net/">lynx</a>, <a href="http://w3m.sourceforge.net/">w3m</a> or <a href="http://elinks.or.cz/">elinks</a> for previews of html pages</li>
     <li>pdftotext for pdf previews</li>
-    <li><a href="http://www.transmissionbt.com/">transmission-show</a> for viewing bit-torrent information</li>
-    <li><a href="http://mediainfo.sourceforge.net/en">mediainfo</a> or exiftool for viewing information about media files</li>
+    <li><a href="https://transmissionbt.com/">transmission-show</a> for viewing bit-torrent information</li>
+    <li><a href="https://mediaarea.net/en/MediaInfo">mediainfo</a> or <a href="http://owl.phy.queensu.ca/~phil/exiftool/">exiftool</a> for viewing information about media files</li>
 </ul>
 
 <!--get foot from index.html-->


### PR DESCRIPTION
A several links have been updated, a couple added, plus a tiny `vim` -> `vi`change:

- `http` -> `https` for several websites - saves a redirect.
- use the original URL for `less`, similarly to the `file` under "Optional" dependencies.
- mention `bash` as a hard dependency - it's not available on every system, i.e. on `OpenBSD` it needs to be installed like any other package.
- added a link to `exiftool`.
- it doesn't seem like there's anything `vim`-specific in the keybinding so change it to `vi` - this is simply to avoid any confusion for people who are familiar with `vi` but don't use `vim`.