### PR TITLE
Basic ranger-like keyboard navigation on website

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -6,19 +6,18 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=0.5" />
         <meta name="ROBOTS" content="NOINDEX, NOFOLLOW" />
-        <script src="jquery2.min.js"></script>
         <link rel="stylesheet" href="style.css" type="text/css" />
     </head>
     <body>
         <div class="index">
-            <a href="index.html" class="ranger filetype_text tagged">README.md</a>
-            <a href="changelog.html" class="ranger filetype_text">CHANGELOG.md</a>
-            <a href="contact.html" class="ranger filetype_text">contact.html</a>
-            <a href="documentation.html" class="ranger filetype_text">docs.html</a>
-            <a href="https://github.com/ranger/ranger" class="ranger filetype_link">github.link</a>
-            <a href="download.html" class="ranger filetype_targz">ranger.tar.gz</a>
-            <a href="screenshots.html" class="ranger filetype_image">screenshot.png</a>
-            <a href="https://github.com/ranger/ranger/wiki" class="ranger filetype_link">wiki.html &nbsp; </a>
+            <a href="index.html" class="ranger filetype_text kbnav tagged">README.md</a>
+            <a href="changelog.html" class="ranger filetype_text kbnav">CHANGELOG.md</a>
+            <a href="contact.html" class="ranger filetype_text kbnav">contact.html</a>
+            <a href="documentation.html" class="ranger filetype_text kbnav">docs.html</a>
+            <a href="https://github.com/ranger/ranger" class="ranger filetype_link kbnav">github.link</a>
+            <a href="download.html" class="ranger filetype_targz kbnav">ranger.tar.gz</a>
+            <a href="screenshots.html" class="ranger filetype_image kbnav">screenshot.png</a>
+            <a href="https://github.com/ranger/ranger/wiki" class="ranger filetype_link kbnav">wiki.html &nbsp; </a>
         </div>
         <div class="content">
 <!--/get-->
@@ -511,6 +510,15 @@ the copied files between ranger instances</li>
 </ul>
 <!--/run-->
 <!--get foot from index.html-->
+		<script type="text/javascript"
+		  src="https://cdnjs.cloudflare.com/ajax/libs/mousetrap/1.6.2/mousetrap.min.js">
+		</script>
+		<script type="text/javascript"
+		  src="https://cdnjs.cloudflare.com/ajax/libs/mousetrap/1.6.2/plugins/bind-dictionary/mousetrap-bind-dictionary.min.js">
+		</script>
+		<script type="text/javascript"
+		  src="keyboard.js">
+		</script>
         </div>
     </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -6,19 +6,18 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=0.5" />
         <meta name="ROBOTS" content="NOINDEX, NOFOLLOW" />
-        <script src="jquery2.min.js"></script>
         <link rel="stylesheet" href="style.css" type="text/css" />
     </head>
     <body>
         <div class="index">
-            <a href="index.html" class="ranger filetype_text tagged">README.md</a>
-            <a href="changelog.html" class="ranger filetype_text">CHANGELOG.md</a>
-            <a href="contact.html" class="ranger filetype_text">contact.html</a>
-            <a href="documentation.html" class="ranger filetype_text">docs.html</a>
-            <a href="https://github.com/ranger/ranger" class="ranger filetype_link">github.link</a>
-            <a href="download.html" class="ranger filetype_targz">ranger.tar.gz</a>
-            <a href="screenshots.html" class="ranger filetype_image">screenshot.png</a>
-            <a href="https://github.com/ranger/ranger/wiki" class="ranger filetype_link">wiki.html &nbsp; </a>
+            <a href="index.html" class="ranger filetype_text kbnav tagged">README.md</a>
+            <a href="changelog.html" class="ranger filetype_text kbnav">CHANGELOG.md</a>
+            <a href="contact.html" class="ranger filetype_text kbnav">contact.html</a>
+            <a href="documentation.html" class="ranger filetype_text kbnav">docs.html</a>
+            <a href="https://github.com/ranger/ranger" class="ranger filetype_link kbnav">github.link</a>
+            <a href="download.html" class="ranger filetype_targz kbnav">ranger.tar.gz</a>
+            <a href="screenshots.html" class="ranger filetype_image kbnav">screenshot.png</a>
+            <a href="https://github.com/ranger/ranger/wiki" class="ranger filetype_link kbnav">wiki.html &nbsp; </a>
         </div>
         <div class="content">
 <!--/get-->
@@ -65,6 +64,15 @@
     <li><b>Akin Fernandez</b>: "Ranger is the file manager we have been waiting for. It perfects an i3 setup." (2016-06-06)</li>
 </ul>
 <!--get foot from index.html-->
+		<script type="text/javascript"
+		  src="https://cdnjs.cloudflare.com/ajax/libs/mousetrap/1.6.2/mousetrap.min.js">
+		</script>
+		<script type="text/javascript"
+		  src="https://cdnjs.cloudflare.com/ajax/libs/mousetrap/1.6.2/plugins/bind-dictionary/mousetrap-bind-dictionary.min.js">
+		</script>
+		<script type="text/javascript"
+		  src="keyboard.js">
+		</script>
         </div>
     </body>
 </html>

--- a/documentation.html
+++ b/documentation.html
@@ -6,19 +6,18 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=0.5" />
         <meta name="ROBOTS" content="NOINDEX, NOFOLLOW" />
-        <script src="jquery2.min.js"></script>
         <link rel="stylesheet" href="style.css" type="text/css" />
     </head>
     <body>
         <div class="index">
-            <a href="index.html" class="ranger filetype_text tagged">README.md</a>
-            <a href="changelog.html" class="ranger filetype_text">CHANGELOG.md</a>
-            <a href="contact.html" class="ranger filetype_text">contact.html</a>
-            <a href="documentation.html" class="ranger filetype_text">docs.html</a>
-            <a href="https://github.com/ranger/ranger" class="ranger filetype_link">github.link</a>
-            <a href="download.html" class="ranger filetype_targz">ranger.tar.gz</a>
-            <a href="screenshots.html" class="ranger filetype_image">screenshot.png</a>
-            <a href="https://github.com/ranger/ranger/wiki" class="ranger filetype_link">wiki.html &nbsp; </a>
+            <a href="index.html" class="ranger filetype_text kbnav tagged">README.md</a>
+            <a href="changelog.html" class="ranger filetype_text kbnav">CHANGELOG.md</a>
+            <a href="contact.html" class="ranger filetype_text kbnav">contact.html</a>
+            <a href="documentation.html" class="ranger filetype_text kbnav">docs.html</a>
+            <a href="https://github.com/ranger/ranger" class="ranger filetype_link kbnav">github.link</a>
+            <a href="download.html" class="ranger filetype_targz kbnav">ranger.tar.gz</a>
+            <a href="screenshots.html" class="ranger filetype_image kbnav">screenshot.png</a>
+            <a href="https://github.com/ranger/ranger/wiki" class="ranger filetype_link kbnav">wiki.html &nbsp; </a>
         </div>
         <div class="content">
 <!--/get-->
@@ -88,6 +87,15 @@ The cheat sheet for version 1.7.0: (<a href="cheatsheet.png">png</a>, <a href="c
 </ul>
 
 <!--get foot from index.html-->
+		<script type="text/javascript"
+		  src="https://cdnjs.cloudflare.com/ajax/libs/mousetrap/1.6.2/mousetrap.min.js">
+		</script>
+		<script type="text/javascript"
+		  src="https://cdnjs.cloudflare.com/ajax/libs/mousetrap/1.6.2/plugins/bind-dictionary/mousetrap-bind-dictionary.min.js">
+		</script>
+		<script type="text/javascript"
+		  src="keyboard.js">
+		</script>
         </div>
     </body>
 </html>

--- a/download.html
+++ b/download.html
@@ -6,19 +6,18 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=0.5" />
         <meta name="ROBOTS" content="NOINDEX, NOFOLLOW" />
-        <script src="jquery2.min.js"></script>
         <link rel="stylesheet" href="style.css" type="text/css" />
     </head>
     <body>
         <div class="index">
-            <a href="index.html" class="ranger filetype_text tagged">README.md</a>
-            <a href="changelog.html" class="ranger filetype_text">CHANGELOG.md</a>
-            <a href="contact.html" class="ranger filetype_text">contact.html</a>
-            <a href="documentation.html" class="ranger filetype_text">docs.html</a>
-            <a href="https://github.com/ranger/ranger" class="ranger filetype_link">github.link</a>
-            <a href="download.html" class="ranger filetype_targz">ranger.tar.gz</a>
-            <a href="screenshots.html" class="ranger filetype_image">screenshot.png</a>
-            <a href="https://github.com/ranger/ranger/wiki" class="ranger filetype_link">wiki.html &nbsp; </a>
+            <a href="index.html" class="ranger filetype_text kbnav tagged">README.md</a>
+            <a href="changelog.html" class="ranger filetype_text kbnav">CHANGELOG.md</a>
+            <a href="contact.html" class="ranger filetype_text kbnav">contact.html</a>
+            <a href="documentation.html" class="ranger filetype_text kbnav">docs.html</a>
+            <a href="https://github.com/ranger/ranger" class="ranger filetype_link kbnav">github.link</a>
+            <a href="download.html" class="ranger filetype_targz kbnav">ranger.tar.gz</a>
+            <a href="screenshots.html" class="ranger filetype_image kbnav">screenshot.png</a>
+            <a href="https://github.com/ranger/ranger/wiki" class="ranger filetype_link kbnav">wiki.html &nbsp; </a>
         </div>
         <div class="content">
 <!--/get-->
@@ -127,6 +126,15 @@ gpg --verify ranger-stable.tar.gz.sig
 </ul>
 
 <!--get foot from index.html-->
+		<script type="text/javascript"
+		  src="https://cdnjs.cloudflare.com/ajax/libs/mousetrap/1.6.2/mousetrap.min.js">
+		</script>
+		<script type="text/javascript"
+		  src="https://cdnjs.cloudflare.com/ajax/libs/mousetrap/1.6.2/plugins/bind-dictionary/mousetrap-bind-dictionary.min.js">
+		</script>
+		<script type="text/javascript"
+		  src="keyboard.js">
+		</script>
         </div>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,19 +6,18 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=0.5" />
         <meta name="ROBOTS" content="NOINDEX, NOFOLLOW" />
-        <script src="jquery2.min.js"></script>
         <link rel="stylesheet" href="style.css" type="text/css" />
     </head>
     <body>
         <div class="index">
-            <a href="index.html" class="ranger filetype_text tagged">README.md</a>
-            <a href="changelog.html" class="ranger filetype_text">CHANGELOG.md</a>
-            <a href="contact.html" class="ranger filetype_text">contact.html</a>
-            <a href="documentation.html" class="ranger filetype_text">docs.html</a>
-            <a href="https://github.com/ranger/ranger" class="ranger filetype_link">github.link</a>
-            <a href="download.html" class="ranger filetype_targz">ranger.tar.gz</a>
-            <a href="screenshots.html" class="ranger filetype_image">screenshot.png</a>
-            <a href="https://github.com/ranger/ranger/wiki" class="ranger filetype_link">wiki.html &nbsp; </a>
+            <a href="index.html" class="ranger filetype_text kbnav tagged">README.md</a>
+            <a href="changelog.html" class="ranger filetype_text kbnav">CHANGELOG.md</a>
+            <a href="contact.html" class="ranger filetype_text kbnav">contact.html</a>
+            <a href="documentation.html" class="ranger filetype_text kbnav">docs.html</a>
+            <a href="https://github.com/ranger/ranger" class="ranger filetype_link kbnav">github.link</a>
+            <a href="download.html" class="ranger filetype_targz kbnav">ranger.tar.gz</a>
+            <a href="screenshots.html" class="ranger filetype_image kbnav">screenshot.png</a>
+            <a href="https://github.com/ranger/ranger/wiki" class="ranger filetype_link kbnav">wiki.html &nbsp; </a>
         </div>
         <div class="content">
 <!--/head-->
@@ -116,6 +115,15 @@ For that, he was given full git access.  We are now a team of four
 <!-- /run -->
         </div>
 <!--foot-->
+		<script type="text/javascript"
+		  src="https://cdnjs.cloudflare.com/ajax/libs/mousetrap/1.6.2/mousetrap.min.js">
+		</script>
+		<script type="text/javascript"
+		  src="https://cdnjs.cloudflare.com/ajax/libs/mousetrap/1.6.2/plugins/bind-dictionary/mousetrap-bind-dictionary.min.js">
+		</script>
+		<script type="text/javascript"
+		  src="keyboard.js">
+		</script>
         </div>
     </body>
 </html>

--- a/keyboard.js
+++ b/keyboard.js
@@ -1,0 +1,47 @@
+var navclass = "kbnav";
+
+function kbNav(key) {
+
+	// convert HTMLCollection to array for indexing
+	var navlinks = [].slice.call(document.getElementsByClassName(navclass));
+	var navindex = -1; // initialize counter before the first post
+
+	var currentfocus = document.activeElement; // get current index of focused post
+
+	// get current post index
+	if ( currentfocus.className.includes(navclass) ) {
+		navindex = navlinks.indexOf(currentfocus);
+	}
+
+	// increment post index
+	if ( key === 'j' && navindex < navlinks.length - 1 ) {
+		navindex++;
+	} else if (key === 'k' && navindex > 0 ) {
+		navindex--;
+	} else if (key === 'g') {
+		navindex = 0;
+	} else if (key === 'G') {
+		navindex = navlinks.length - 1;
+	}
+
+	// move focus
+	navlinks[navindex].focus();
+}
+
+function kbLaunch() {
+	var currentfocus = document.activeElement; // get current index of focused post
+	// open focused link
+	if ( currentfocus.className.includes(navclass) ) {
+		window.location.href = currentfocus;
+	}
+
+}
+
+Mousetrap.bind({
+	'j': function() { kbNav('j'); },
+	'k': function() { kbNav('k'); },
+	'g g': function() { kbNav('g'); },
+	'G': function() { kbNav('G'); },
+	'l': function() { kbLaunch(); },
+	'g h': function() { window.location.href = "index.html"; }
+})

--- a/screenshots.html
+++ b/screenshots.html
@@ -6,19 +6,18 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=0.5" />
         <meta name="ROBOTS" content="NOINDEX, NOFOLLOW" />
-        <script src="jquery2.min.js"></script>
         <link rel="stylesheet" href="style.css" type="text/css" />
     </head>
     <body>
         <div class="index">
-            <a href="index.html" class="ranger filetype_text tagged">README.md</a>
-            <a href="changelog.html" class="ranger filetype_text">CHANGELOG.md</a>
-            <a href="contact.html" class="ranger filetype_text">contact.html</a>
-            <a href="documentation.html" class="ranger filetype_text">docs.html</a>
-            <a href="https://github.com/ranger/ranger" class="ranger filetype_link">github.link</a>
-            <a href="download.html" class="ranger filetype_targz">ranger.tar.gz</a>
-            <a href="screenshots.html" class="ranger filetype_image">screenshot.png</a>
-            <a href="https://github.com/ranger/ranger/wiki" class="ranger filetype_link">wiki.html &nbsp; </a>
+            <a href="index.html" class="ranger filetype_text kbnav tagged">README.md</a>
+            <a href="changelog.html" class="ranger filetype_text kbnav">CHANGELOG.md</a>
+            <a href="contact.html" class="ranger filetype_text kbnav">contact.html</a>
+            <a href="documentation.html" class="ranger filetype_text kbnav">docs.html</a>
+            <a href="https://github.com/ranger/ranger" class="ranger filetype_link kbnav">github.link</a>
+            <a href="download.html" class="ranger filetype_targz kbnav">ranger.tar.gz</a>
+            <a href="screenshots.html" class="ranger filetype_image kbnav">screenshot.png</a>
+            <a href="https://github.com/ranger/ranger/wiki" class="ranger filetype_link kbnav">wiki.html &nbsp; </a>
         </div>
         <div class="content">
 <!--/get-->
@@ -44,6 +43,15 @@
 </p>
 
 <!--get foot from index.html-->
+		<script type="text/javascript"
+		  src="https://cdnjs.cloudflare.com/ajax/libs/mousetrap/1.6.2/mousetrap.min.js">
+		</script>
+		<script type="text/javascript"
+		  src="https://cdnjs.cloudflare.com/ajax/libs/mousetrap/1.6.2/plugins/bind-dictionary/mousetrap-bind-dictionary.min.js">
+		</script>
+		<script type="text/javascript"
+		  src="keyboard.js">
+		</script>
         </div>
     </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -57,35 +57,35 @@ code {
 .filetype_image {
     color: #ffbb00;
 }
-.filetype_image:hover {
+.filetype_image:hover, .filetype_image:focus {
     color: black;
     background-color: #ffbb00;
 }
 .filetype_text {
     color: white;
 }
-.filetype_text:hover {
+.filetype_text:hover, .filetype_text:focus {
     color: black;
     background-color: white;
 }
 .filetype_directory {
     color: #66f;
 }
-.filetype_directory:hover {
+.filetype_directory:hover, .filetype_directory:focus {
     color: black;
     background-color: #66f;
 }
 .filetype_link {
     color: #0CC;
 }
-.filetype_link:hover {
+.filetype_link:hover, .filetype_link:focus {
     color: black;
     background-color: #0CC;
 }
 .filetype_targz {
     color: #c44;
 }
-.filetype_targz:hover {
+.filetype_targz:hover, .filetype_targz:focus {
     color: black;
     background-color: #c44;
 }


### PR DESCRIPTION
I was really tickled by the ranger-like website styling, so I decided to add some basic ranger-like keyboard navigation. I used [Mousetrap.js](https://github.com/ccampbell/mousetrap) to implement a few keybindings:

- `j/k` to navigate down/up the "file listing"
- `gg/G` to go to top/bottom of the listing
- `l/Enter` to open the link
- `gh` to go back to homepage

The logic is pretty easy to implement, so I can add more if you have requests.

Here's how it works, in brief. I have some javascript in `keyboard.js` that finds all the html elements of class `kbnav` (the navigation links / "file listing") and puts them into an array. Then Mousetrap can capture keystrokes and dispatch a function to move the browser focus to the appropriate link in the array.

I've been using Mousetrap on [my website](https://tobanwiebe.com/) (also hosted with Github Pages), which you can play with for a working example.

(I also removed the line sourcing `jquery2.min.js` as it's unused -- in fact, the file itself isn't even present in the repo.)