### PR TITLE
contact: Update GitHub locations to ranger org

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -35,7 +35,7 @@
 <li>The IRC channel #ranger on <a
     href="https://libera.chat/guides/connect">Libera.Chat</a></li>
 <li>The mailing list <a href="https://lists.nongnu.org/mailman/listinfo/ranger-users">ranger-users</a> (<a href="http://lists.nongnu.org/archive/html/ranger-users/">archive</a>)</li>
-<li>Bug tracker on <a href="https://github.com/hut/ranger/issues">GitHub</a></li>
+<li>Bug tracker on <a href="https://github.com/ranger/ranger/issues">GitHub Issues</a></li>
 <li>Direct e-mail to the author: hut at hut.pm</li>
 </ul>
 
@@ -47,7 +47,7 @@
 <ul>
 <li><a href="https://wiki.archlinux.org/index.php/Ranger">Arch Linux Wiki</a></li>
 <li><a href="http://savannah.nongnu.org/projects/ranger/">Savannah</a></li>
-<li><a href="https://github.com/hut/ranger">github</a></li>
+<li><a href="https://github.com/ranger/ranger">GitHub</a></li>
 </ul>
 <!--* <a href="http://freshmeat.net/projects/ranger">freshmeat</a>
 <ul>


### PR DESCRIPTION
The repo moved to the ranger org ages ago.